### PR TITLE
chore: renovate automerge for minors and patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,11 @@
         "digest"
       ],
       "groupName": "all cloudnative-pg daggerverse dependencies"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Let every minor and patch dependency update be merged without human supervision if tests pass.