### PR TITLE
ci: update dependendencies

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dagger
         env:
           # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.10.3
+          DAGGER_VERSION: 0.11.9
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
       - name: Run CI task

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,96 +13,10 @@ linters-settings:
       - G101 # remove this exclude when https://github.com/securego/gosec/issues/1001 is fixed
 
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
-  enable:
-    - asciicheck
-    - bodyclose
-    - dogsled
-    - dupl
-    - durationcheck
-    - errcheck
-    - exportloopref
-    - gci
-    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-    - gofmt
-    - gofumpt
-    - goheader
-    - goimports
-    - gomoddirectives
-    - gomodguard
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ginkgolinter
-    - importas
-    - ineffassign
-    - lll
-    - makezero
-    - misspell
-    - nakedret
-    - nestif
-    - prealloc
-    - predeclared
-    - revive
-    - rowserrcheck
-    - sqlclosecheck
-    - staticcheck
-    - stylecheck
-    - thelper
-    - tparallel
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - wastedassign
-    - whitespace
-
-  # to be checked:
-  # - errorlint
-  # - forbidigo
-  # - forcetypeassert
-  # - goerr113
-  # - ifshort
-  # - nilerr
-  # - nlreturn
-  # - noctx
-  # - nolintlint
-  # - paralleltest
-  # - promlinter
-  # - tagliatelle
-  # - wrapcheck
-
-  # don't enable:
-  # - cyclop
-  # - depguard
-  # - exhaustive
-  # - exhaustivestruct
-  # - funlen
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - godot
-  # - godox
-  # - gomnd
-  # - testpackage
-  # - wsl
-
-  # deprecated:
-  # - deadcode
-  # - golint
-  # - interfacer
-  # - maligned
-  # - scopelint
-  # - structcheck
-  # - varcheck
-
-run:
-  skip-files: "zz_generated.*"
+  enable-all: true
+  disable:
+    - execinquery
+    - gomnd
 
 issues:
   exclude-rules:
@@ -126,3 +40,5 @@ issues:
       text: "ST1016:"
       path: api/
   exclude-use-default: false
+  exclude-files:
+    - "zz_generated.*"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,7 +31,7 @@ tasks:
       - protoc-gen-go-grpc
     env:
       # renovate: datasource=git-refs depName=golangci-lint lookupName=https://github.com/sagikazarmark/daggerverse currentValue=main
-      DAGGER_GOLANGCI_LINT_SHA: 9a3074edb9cb21746ea2f9dcdd018d520b47f2e6
+      DAGGER_GOLANGCI_LINT_SHA: b249f27c0d6a2183cd368ae767fc912a09a1a40f
     cmds:
       - >
         dagger -s call -m github.com/sagikazarmark/daggerverse/golangci-lint@${DAGGER_GOLANGCI_LINT_SHA}
@@ -49,19 +49,6 @@ tasks:
     sources:
       - proto/**/*.proto
 
-  build:
-    desc: Build the project
-    deps:
-      - lint
-      - protoc-gen-doc
-    env:
-      # renovate: datasource=git-refs depName=golang lookupName=https://github.com/kpenfound/dagger-modules currentValue=main
-      DAGGER_GOLANG_SHA: 57352e06a1cfbcb5307c009d37c0201b2719b935
-    cmds:
-      - >
-        dagger -s -m github.com/kpenfound/dagger-modules/golang@${DAGGER_GOLANG_SHA}
-        call base --version 1.22-bookworm build --source . --args ./...
-
   commitlint:
     desc: Check for conventional commits
     env:
@@ -73,7 +60,8 @@ tasks:
   uncommitted:
     desc: Check for uncommitted changes
     deps:
-      - build
+      - lint
+      - protoc-gen-doc
     env:
       # renovate: datasource=git-refs depName=uncommitted lookupName=https://github.com/cloudnative-pg/daggerverse currentValue=main
       DAGGER_UNCOMMITTED_SHA: 9312a7826b1c8b5e67a44a12b092ab13a529adb7

--- a/pkg/operator/extensions.go
+++ b/pkg/operator/extensions.go
@@ -21,8 +21,8 @@ func (v ValidationErrors) Error() string {
 func (v *ValidationError) Error() string {
 	return fmt.Sprintf(
 		"encountered a validation error, message: %s, value: %s, pathComponents: %s",
-		v.Message,
-		v.Value,
-		v.PathComponents,
+		v.GetMessage(),
+		v.GetValue(),
+		v.GetPathComponents(),
 	)
 }


### PR DESCRIPTION
Update dagger engine and golang-ci versions in the ci.

Remove unused build step.

Change the golang-ci configuration to run additional linters and remove deprecated options.

Fix linter suggestions in the code.