### PR TITLE
ci: unpin release-please version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,15 +21,11 @@ jobs:
           node-version: 20
       # TODO: remove bump-minor-pre-major when in production. It prevents
       #   release-please from bumping the major version on breaking changes.
-      # TODO: remove release-as after first release. Used to set the first
-      #   release version, which would default to 1.0.0. Set the version
-      #   manually also for 1.0.0.
       - run: |
           npx release-please release-pr \
             --token="${{ secrets.REPO_PAT }}" \
             --repo-url="${{ github.repository }}" \
             --bump-minor-pre-major=true \
-            --release-as=0.1.0 \
             --signoff "Peggie <info@cloudnative-pg.io>";
           npx release-please github-release \
             --token="${{ secrets.REPO_PAT }}" \


### PR DESCRIPTION
Allow release-please to tag versions after 0.1.0, according to conventional commits rules.