### PR TITLE
ci: migrate golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,44 +1,51 @@
-linters-settings:
-  lll:
-    line-length: 120
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/cloudnative-pg/cloudnative-pg)
-      - blank
-      - dot
-  gosec:
-    excludes:
-      - G101 # remove this exclude when https://github.com/securego/gosec/issues/1001 is fixed
-
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    - execinquery
-    - gomnd
-
-issues:
-  exclude-rules:
-    # Allow dot imports for ginkgo and gomega
-    - source: ginkgo|gomega
-      linters:
-      - revive
-      text: "should not use dot imports"
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - goconst
-    # Exclude lll issues for lines with long annotations
-    - linters:
-      - lll
-      source: "//\\s*\\+"
-    # We have no control of this in zz_generated files and it looks like that excluding those files is not enough
-    # so we disable "ST1016: methods on the same type should have the same receiver name" in api directory
-    - linters:
-      - stylecheck
-      text: "ST1016:"
-      path: api/
-  exclude-use-default: false
-  exclude-files:
-    - "zz_generated.*"
+    - mnd
+  settings:
+    lll:
+      line-length: 120
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        text: should not use dot imports
+        source: ginkgo|gomega
+      - linters:
+          - goconst
+        path: _test\.go
+      - linters:
+          - lll
+        source: //\s*\+
+      - linters:
+          - staticcheck
+        path: api/
+        text: 'ST1016:'
+    paths:
+      - zz_generated.*
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/cloudnative-pg/cloudnative-pg)
+        - blank
+        - dot
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated.*
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Migrate golangci-lint configuration to v2.

Closes #180
